### PR TITLE
Replace AOM with SVT‑AV1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
 project(MRDesktop)
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(SVTAV1 REQUIRED IMPORTED_TARGET SvtAv1Enc)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -36,7 +39,7 @@ if(PLATFORM_DESKTOP)
         src/shared/H264Encoder.cpp
         src/shared/AV1Encoder.cpp
     )
-    target_include_directories(MRDesktopServer PRIVATE ${COMMON_INCLUDES})
+    target_include_directories(MRDesktopServer PRIVATE ${COMMON_INCLUDES} ${SVTAV1_INCLUDE_DIRS})
 
     # Create console client executable
     add_executable(MRDesktopConsoleClient
@@ -44,20 +47,21 @@ if(PLATFORM_DESKTOP)
         src/shared/FrameLogger.cpp
         src/shared/FrameReceiver.cpp
     )
-    target_include_directories(MRDesktopConsoleClient PRIVATE ${COMMON_INCLUDES})
+    target_include_directories(MRDesktopConsoleClient PRIVATE ${COMMON_INCLUDES} ${SVTAV1_INCLUDE_DIRS})
 
     if(WIN32)
         # Server needs DXGI, Media Foundation and other Windows APIs
         target_compile_definitions(MRDesktopServer PRIVATE WIN32_LEAN_AND_MEAN)
-        target_link_libraries(MRDesktopServer PRIVATE dxgi d3d11 ws2_32 mf mfplat mfuuid wmcodecdspuuid aom)
+        target_link_libraries(MRDesktopServer PRIVATE dxgi d3d11 ws2_32 mf mfplat mfuuid wmcodecdspuuid SvtAv1Enc)
         
         # Console client
         target_compile_definitions(MRDesktopConsoleClient PRIVATE WIN32_LEAN_AND_MEAN)
-        target_link_libraries(MRDesktopConsoleClient PRIVATE ws2_32)
+        target_link_libraries(MRDesktopConsoleClient PRIVATE ws2_32 SvtAv1Enc)
     endif()
 
     if(NOT WIN32)
-        target_link_libraries(MRDesktopServer PRIVATE aom)
+        target_link_libraries(MRDesktopServer PRIVATE SvtAv1Enc)
+        target_link_libraries(MRDesktopConsoleClient PRIVATE SvtAv1Enc)
     endif()
     
     # Add Windows GUI client as a subdirectory

--- a/src/shared/AV1Encoder.cpp
+++ b/src/shared/AV1Encoder.cpp
@@ -3,7 +3,7 @@
 
 AV1Encoder::AV1Encoder()
     : m_width(0), m_height(0), m_fps(60), m_initialized(false), m_forceKeyframe(false), m_frameCount(0) {
-    std::memset(&m_codec, 0, sizeof(m_codec));
+    m_handle = nullptr;
     std::memset(&m_cfg, 0, sizeof(m_cfg));
 }
 
@@ -16,19 +16,18 @@ bool AV1Encoder::Initialize(int width, int height, int fps) {
     m_frameCount = 0;
     m_forceKeyframe = false;
 
-    const aom_codec_iface_t* iface = aom_codec_av1_cx();
-    if (aom_codec_enc_config_default(iface, &m_cfg, 0) != AOM_CODEC_OK)
+    if (svt_av1_enc_init_handle(&m_handle, nullptr, &m_cfg) != EB_ErrorNone)
         return false;
 
-    m_cfg.g_w = width;
-    m_cfg.g_h = height;
-    m_cfg.g_timebase.num = 1;
-    m_cfg.g_timebase.den = fps;
-    m_cfg.rc_target_bitrate = 5000; // kbps
-    m_cfg.g_error_resilient = 0;
-    m_cfg.g_threads = 2;
+    m_cfg.source_width = width;
+    m_cfg.source_height = height;
+    m_cfg.frame_rate_numerator = fps;
+    m_cfg.frame_rate_denominator = 1;
 
-    if (aom_codec_init(&m_codec, iface, &m_cfg, 0) != AOM_CODEC_OK)
+    if (svt_av1_enc_set_parameter(m_handle, &m_cfg) != EB_ErrorNone)
+        return false;
+
+    if (svt_av1_enc_init(m_handle) != EB_ErrorNone)
         return false;
 
     m_initialized = true;
@@ -67,24 +66,29 @@ bool AV1Encoder::EncodeFrame(const uint8_t* frameData, std::vector<uint8_t>& com
     std::vector<uint8_t> yuv;
     BGRAtoI420(frameData, m_width, m_height, yuv);
 
-    aom_image_t raw;
-    aom_img_wrap(&raw, AOM_IMG_FMT_I420, m_width, m_height, 1, yuv.data());
+    EbBufferHeaderType input;
+    std::memset(&input, 0, sizeof(input));
+    input.size = sizeof(EbBufferHeaderType);
+    input.p_buffer = yuv.data();
+    input.n_filled_len = static_cast<uint32_t>(yuv.size());
+    input.n_alloc_len = static_cast<uint32_t>(yuv.size());
+    input.pic_type = m_forceKeyframe ? EB_AV1_KEY_PICTURE : EB_AV1_INVALID_PICTURE;
+    input.pts = m_frameCount;
 
-    int flags = m_forceKeyframe ? AOM_EFLAG_FORCE_KF : 0;
-    if (aom_codec_encode(&m_codec, &raw, m_frameCount, 1, flags) != AOM_CODEC_OK)
+    if (svt_av1_enc_send_picture(m_handle, &input) != EB_ErrorNone)
         return false;
 
     m_forceKeyframe = false;
 
-    aom_codec_iter_t iter = nullptr;
-    const aom_codec_cx_pkt_t* pkt = nullptr;
+    EbBufferHeaderType* output = nullptr;
     compressedData.clear();
-    while ((pkt = aom_codec_get_cx_data(&m_codec, &iter)) != nullptr) {
-        if (pkt->kind == AOM_CODEC_CX_FRAME_PKT) {
-            const uint8_t* buf = static_cast<const uint8_t*>(pkt->data.frame.buf);
-            compressedData.insert(compressedData.end(), buf, buf + pkt->data.frame.sz);
-            isKeyframe = (pkt->data.frame.flags & AOM_FRAME_IS_KEY) != 0;
+    while (svt_av1_enc_get_packet(m_handle, &output, 0) == EB_ErrorNone) {
+        if (output && output->n_filled_len > 0) {
+            const uint8_t* buf = output->p_buffer;
+            compressedData.insert(compressedData.end(), buf, buf + output->n_filled_len);
+            isKeyframe = output->pic_type == EB_AV1_KEY_PICTURE;
         }
+        svt_av1_enc_release_out_buffer(&output);
     }
 
     m_frameCount++;
@@ -95,7 +99,9 @@ void AV1Encoder::ForceKeyframe() { m_forceKeyframe = true; }
 
 void AV1Encoder::Cleanup() {
     if (m_initialized) {
-        aom_codec_destroy(&m_codec);
+        svt_av1_enc_deinit(m_handle);
+        svt_av1_enc_deinit_handle(m_handle);
+        m_handle = nullptr;
         m_initialized = false;
     }
 }

--- a/src/shared/AV1Encoder.h
+++ b/src/shared/AV1Encoder.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <vector>
-#include <aom/aom_encoder.h>
-#include <aom/aomcx.h>
+#include <svt-av1/EbSvtAv1Enc.h>
 
 class AV1Encoder {
 public:
@@ -20,6 +19,6 @@ private:
     bool m_initialized;
     bool m_forceKeyframe;
     int m_frameCount;
-    aom_codec_ctx_t m_codec;
-    aom_codec_enc_cfg_t m_cfg;
+    EbComponentType* m_handle;
+    EbSvtAv1EncConfiguration m_cfg;
 };


### PR DESCRIPTION
## Summary
- switch AV1 encoder implementation to use SVT‑AV1
- link server and client targets with `SvtAv1Enc`
- include SVT‑AV1 headers via PkgConfig

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: `svt-av1/EbSvtAv1Enc.h: No such file or directory` when cross‑compiling for Windows)*

------
https://chatgpt.com/codex/tasks/task_e_68831bb103a4832b9f39ba6ae38a9691