### PR TITLE
Add FFmpeg support via vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(MRDesktop)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(SVTAV1 REQUIRED IMPORTED_TARGET SvtAv1Enc)
+pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavcodec libavformat libavutil libswresample libswscale)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -39,7 +40,7 @@ if(PLATFORM_DESKTOP)
         src/shared/H264Encoder.cpp
         src/shared/AV1Encoder.cpp
     )
-    target_include_directories(MRDesktopServer PRIVATE ${COMMON_INCLUDES} ${SVTAV1_INCLUDE_DIRS})
+    target_include_directories(MRDesktopServer PRIVATE ${COMMON_INCLUDES} ${SVTAV1_INCLUDE_DIRS} ${FFMPEG_INCLUDE_DIRS})
 
     # Create console client executable
     add_executable(MRDesktopConsoleClient
@@ -47,21 +48,29 @@ if(PLATFORM_DESKTOP)
         src/shared/FrameLogger.cpp
         src/shared/FrameReceiver.cpp
     )
-    target_include_directories(MRDesktopConsoleClient PRIVATE ${COMMON_INCLUDES} ${SVTAV1_INCLUDE_DIRS})
+    target_include_directories(MRDesktopConsoleClient PRIVATE ${COMMON_INCLUDES} ${SVTAV1_INCLUDE_DIRS} ${FFMPEG_INCLUDE_DIRS})
 
     if(WIN32)
         # Server needs DXGI, Media Foundation and other Windows APIs
         target_compile_definitions(MRDesktopServer PRIVATE WIN32_LEAN_AND_MEAN)
-        target_link_libraries(MRDesktopServer PRIVATE dxgi d3d11 ws2_32 mf mfplat mfuuid wmcodecdspuuid SvtAv1Enc)
+        target_link_libraries(MRDesktopServer PRIVATE dxgi d3d11 ws2_32 mf mfplat mfuuid wmcodecdspuuid
+            PkgConfig::libavcodec PkgConfig::libavformat PkgConfig::libavutil PkgConfig::libswresample PkgConfig::libswscale
+            SvtAv1Enc)
         
         # Console client
         target_compile_definitions(MRDesktopConsoleClient PRIVATE WIN32_LEAN_AND_MEAN)
-        target_link_libraries(MRDesktopConsoleClient PRIVATE ws2_32 SvtAv1Enc)
+        target_link_libraries(MRDesktopConsoleClient PRIVATE ws2_32
+            PkgConfig::libavcodec PkgConfig::libavformat PkgConfig::libavutil PkgConfig::libswresample PkgConfig::libswscale
+            SvtAv1Enc)
     endif()
 
     if(NOT WIN32)
-        target_link_libraries(MRDesktopServer PRIVATE SvtAv1Enc)
-        target_link_libraries(MRDesktopConsoleClient PRIVATE SvtAv1Enc)
+        target_link_libraries(MRDesktopServer PRIVATE
+            PkgConfig::libavcodec PkgConfig::libavformat PkgConfig::libavutil PkgConfig::libswresample PkgConfig::libswscale
+            SvtAv1Enc)
+        target_link_libraries(MRDesktopConsoleClient PRIVATE
+            PkgConfig::libavcodec PkgConfig::libavformat PkgConfig::libavutil PkgConfig::libswresample PkgConfig::libswscale
+            SvtAv1Enc)
     endif()
     
     # Add Windows GUI client as a subdirectory

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,10 +1,15 @@
 {
   "name": "mrdesktop",
-  "version": "0.1.0",
-  "description": "VR/MR Virtual Desktop for Meta Quest 3",
+  "version-string": "0.1.0",
+  "builtin-baseline": "dd3097e305afa53f7b4312371f62058d2e665320",
   "dependencies": [
-    "x265",
-    "ffmpeg"
-  ],
-  "builtin-baseline": "dd3097e305afa53f7b4312371f62058d2e665320"
+    {
+      "name": "ffmpeg",
+      "default-features": false,
+      "features": [
+        "avcodec", "avformat", "swresample", "swscale",
+        "nvcodec", "nonfree"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- enable FFmpeg `nvcodec` and `nonfree` features in vcpkg
- look up FFmpeg libs with pkg-config in CMake
- link FFmpeg libraries to server and client targets

## Testing
- `cmake -B build -S .` *(fails: Package 'SvtAv1Enc', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b3e7bf4c832b9f0120ba50227d49