### PR TITLE
Fix OnFrameReceived execution

### DIFF
--- a/src/clients/unreal/Source/PTSamples/MRClient.cpp
+++ b/src/clients/unreal/Source/PTSamples/MRClient.cpp
@@ -238,10 +238,7 @@ bool MRClient::ReceiveFrameData()
     // Call the frame received callback on the game thread
     AsyncTask(ENamedThreads::GameThread, [this, FrameData = MoveTemp(FrameData)]()
     {
-        if (OnFrameReceived.IsBound())
-        {
-            OnFrameReceived.Execute(FrameData);
-        }
+        OnFrameReceived.ExecuteIfBound(FrameData);
     });
 
     return true;


### PR DESCRIPTION
## Summary
- call `OnFrameReceived.ExecuteIfBound` in `MRClient::ReceiveFrameData`

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build` *(fails: `windows.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b4851750832bb06fa24382ff5ddb