### PR TITLE
Force release ffmpeg libs

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -20,6 +20,9 @@
                 "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/install/debug"
             },
+            "environment": {
+                "VCPKG_BUILD_TYPE": "release"
+            },
             "condition": {
                 "type": "equals",
                 "lhs": "${hostSystemName}",
@@ -62,6 +65,9 @@
                 "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/install/debug"
             },
+            "environment": {
+                "VCPKG_BUILD_TYPE": "release"
+            },
             "condition": {
                 "type": "equals",
                 "lhs": "${hostSystemName}",
@@ -101,7 +107,8 @@
             },
             "toolchainFile": "$env{CMAKE_ANDROID_NDK}/build/cmake/android.toolchain.cmake",
             "environment": {
-                "CMAKE_ANDROID_NDK": "$env{ANDROID_NDK_HOME}"
+                "CMAKE_ANDROID_NDK": "$env{ANDROID_NDK_HOME}",
+                "VCPKG_BUILD_TYPE": "release"
             }
         },
         {
@@ -121,7 +128,8 @@
             },
             "toolchainFile": "${sourceDir}/extern/vcpkg/scripts/buildsystems/vcpkg.cmake",
             "environment": {
-                "CMAKE_ANDROID_NDK": "$env{ANDROID_NDK_HOME}"
+                "CMAKE_ANDROID_NDK": "$env{ANDROID_NDK_HOME}",
+                "VCPKG_BUILD_TYPE": "release"
             }
         },
         {
@@ -159,7 +167,8 @@
             },
             "toolchainFile": "$env{CMAKE_ANDROID_NDK}/build/cmake/android.toolchain.cmake",
             "environment": {
-                "CMAKE_ANDROID_NDK": "$env{ANDROID_NDK_HOME}"
+                "CMAKE_ANDROID_NDK": "$env{ANDROID_NDK_HOME}",
+                "VCPKG_BUILD_TYPE": "release"
             }
         }
     ],

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
   * `tools\build_apk_standalone.bat`
 * for an OpenXR build targeting Quest 3 use the `android-openxr-arm64-debug` preset (requires `vcpkg` and the `openxr-loader` package)
 
+This repository always links against the release build of FFmpeg. The build scripts set the environment variable `VCPKG_BUILD_TYPE=release` so that vcpkg provides release libraries even when the project itself is compiled in debug mode.
+
 [README_ANDROID.md](README_ANDROID.md)
 
 ## Testing

--- a/build_android.sh
+++ b/build_android.sh
@@ -34,6 +34,9 @@ fi
 
 echo "Found Android NDK at: $ANDROID_NDK_HOME"
 
+# Always use release libraries from vcpkg (e.g. FFmpeg)
+export VCPKG_BUILD_TYPE=release
+
 # Set environment variables
 export CMAKE_ANDROID_NDK="$ANDROID_NDK_HOME"
 

--- a/configure.bat
+++ b/configure.bat
@@ -8,6 +8,9 @@ if "%1"=="Release" set BUILD_TYPE=Release
 
 echo Build type: %BUILD_TYPE%
 
+REM Always use release libraries from vcpkg (e.g. FFmpeg)
+set VCPKG_BUILD_TYPE=release
+
 REM Initialize vcpkg submodule if not already done
 if not exist "extern\vcpkg\.git" (
     echo Initializing vcpkg submodule...


### PR DESCRIPTION
## Summary
- ensure vcpkg packages are built in release mode
- document the use of `VCPKG_BUILD_TYPE=release`

## Testing
- `cmake -B build -S .` *(fails: Package 'SvtAv1Enc', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b78b1840832bb46be4a9ff43ed3b