### PR TITLE
Fix CI workflow by installing nasm

### DIFF
--- a/.github/workflows/compression-test.yml
+++ b/.github/workflows/compression-test.yml
@@ -23,6 +23,7 @@ jobs:
           ninja-build \
           cmake \
           build-essential \
+          nasm \
           pkg-config \
           libavcodec-dev \
           libavformat-dev \


### PR DESCRIPTION
## Summary
- install `nasm` during dependency setup so x265 can build

## Testing
- `bash run_compression_test.sh` *(fails: Server not found)*
- `cmake --preset linux-debug` *(fails: vcpkg install failed)*

------
https://chatgpt.com/codex/tasks/task_e_68848a35d8c4832b8b3756b9ff111428