### PR TITLE
Fix missing build tools for vcpkg

### DIFF
--- a/.github/workflows/compression-test.yml
+++ b/.github/workflows/compression-test.yml
@@ -23,6 +23,9 @@ jobs:
           ninja-build \
           cmake \
           build-essential \
+          autoconf \
+          automake \
+          libtool \
           pkg-config \
           libavcodec-dev \
           libavformat-dev \


### PR DESCRIPTION
## Summary
- install autotools packages for CI build

## Testing
- `cmake --preset linux-debug` (fails later in ffmpeg build)


------
https://chatgpt.com/codex/tasks/task_e_6884a1b5d2fc832baa12cc3179fa2584