### PR TITLE
Fix linux compile type errors

### DIFF
--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -27,6 +27,14 @@ using SOCKET = int;
 #include "protocol.h"
 #include "VideoEncoder.h"
 
+#ifndef _WIN32
+#include <cstdint>
+using BYTE = uint8_t;
+using UINT = uint32_t;
+using UINT32 = uint32_t;
+using INT32 = int32_t;
+#endif
+
 #ifdef _WIN32
 class DesktopDuplicator {
 private:


### PR DESCRIPTION
## Summary
- add missing typedefs for non-Windows builds so BYTE and UINT32 resolve

## Testing
- `g++ -std=c++20 -c src/server/main.cpp -Iinclude -Isrc/shared`

------
https://chatgpt.com/codex/tasks/task_e_6884adfbce2c832b902afdd1266edc84