### PR TITLE
Add vcpkg cache to workflow

### DIFF
--- a/.github/workflows/compression-test.yml
+++ b/.github/workflows/compression-test.yml
@@ -15,6 +15,18 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+
+    - name: Cache vcpkg
+      uses: actions/cache@v3
+      with:
+        path: |
+          extern/vcpkg/buildtrees
+          extern/vcpkg/packages
+          extern/vcpkg/downloads
+          extern/vcpkg/installed
+        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-
     
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Summary
- reuse compiled vcpkg artifacts to avoid rebuilding every workflow run

## Testing
- `bash -n run_compression_test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6884b8fc0ed0832b81adbc55bd86ff23