### PR TITLE
Modify compression-test workflow to stop after vcpkg

### DIFF
--- a/.github/workflows/compression-test.yml
+++ b/.github/workflows/compression-test.yml
@@ -53,21 +53,21 @@ jobs:
         ./bootstrap-vcpkg.sh
         ./vcpkg integrate install
     
-    - name: Configure CMake
-      run: cmake --preset linux-debug
-    
-    - name: Build
-      run: cmake --build --preset linux-debug
-    
-    - name: Run H.265 Compression Test
-      run: ./run_compression_test.sh
-      
-    - name: Upload test artifacts on failure
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-artifacts
-        path: |
-          first_frame.bmp
-          debug_frames/
-        retention-days: 3
+    # - name: Configure CMake
+    #   run: cmake --preset linux-debug
+
+    # - name: Build
+    #   run: cmake --build --preset linux-debug
+
+    # - name: Run H.265 Compression Test
+    #   run: ./run_compression_test.sh
+
+    # - name: Upload test artifacts on failure
+    #   if: failure()
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: test-artifacts
+    #     path: |
+    #       first_frame.bmp
+    #       debug_frames/
+    #     retention-days: 3


### PR DESCRIPTION
## Summary
- comment out CMake configure, build and test steps in `compression-test.yml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884bf1d800c832b87a07ff63e4bf310