### PR TITLE
Fix GH action build steps

### DIFF
--- a/.github/workflows/compression-test.yml
+++ b/.github/workflows/compression-test.yml
@@ -53,11 +53,11 @@ jobs:
         ./bootstrap-vcpkg.sh
         ./vcpkg integrate install
     
-    # - name: Configure CMake
-    #   run: cmake --preset linux-debug
+    - name: Configure CMake
+      run: cmake --preset linux-debug
 
-    # - name: Build
-    #   run: cmake --build --preset linux-debug
+    - name: Build
+      run: cmake --build --preset linux-debug
 
     # - name: Run H.265 Compression Test
     #   run: ./run_compression_test.sh


### PR DESCRIPTION
## Summary
- make sure compression test workflow configures and builds the project again

## Testing
- `cmake --preset linux-debug`
- `cmake --build --preset linux-debug`


------
https://chatgpt.com/codex/tasks/task_e_6884c1ae36e0832ba8c0eabaf23de95e