### PR TITLE
Split vcpkg setup into its own workflow job

### DIFF
--- a/.github/workflows/compression-test.yml
+++ b/.github/workflows/compression-test.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  test-compression:
+  vcpkg:
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -27,7 +27,7 @@ jobs:
         key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
         restore-keys: |
           ${{ runner.os }}-vcpkg-
-    
+
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -46,13 +46,62 @@ jobs:
           libswscale-dev \
           libavdevice-dev \
           libavfilter-dev
-    
+
     - name: Setup vcpkg
       run: |
         cd extern/vcpkg
         ./bootstrap-vcpkg.sh
         ./vcpkg integrate install
-    
+
+  test-compression:
+    runs-on: ubuntu-latest
+    needs: vcpkg
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Restore vcpkg from cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          extern/vcpkg/buildtrees
+          extern/vcpkg/packages
+          extern/vcpkg/downloads
+          extern/vcpkg/installed
+        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-
+
+    - name: Cache build
+      uses: actions/cache@v3
+      with:
+        path: |
+          build
+        key: ${{ runner.os }}-build-${{ hashFiles('**/CMakeLists.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-build-
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          ninja-build \
+          cmake \
+          build-essential \
+          autoconf \
+          automake \
+          libtool \
+          nasm \
+          pkg-config \
+          libavcodec-dev \
+          libavformat-dev \
+          libavutil-dev \
+          libswscale-dev \
+          libavdevice-dev \
+          libavfilter-dev
+
     - name: Configure CMake
       run: cmake --preset linux-debug
 


### PR DESCRIPTION
## Summary
- create a new `vcpkg` job and move dependency setup there
- add a `test-compression` job that depends on `vcpkg`
- cache cmake build results separately

## Testing
- `bash run_compression_test.sh` *(fails: Server not found)*

------
https://chatgpt.com/codex/tasks/task_e_688513f30a30832b9e2054d4142e11f2