### PR TITLE
Fix unsupported anchor in GH workflow

### DIFF
--- a/.github/workflows/compression-test.yml
+++ b/.github/workflows/compression-test.yml
@@ -28,8 +28,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-vcpkg-
 
-    - &install-deps
-      name: Install dependencies
+    - name: Install dependencies
       run: |
         sudo apt-get update
         sudo apt-get install -y \
@@ -84,7 +83,24 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-build-
 
-    - *install-deps
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          ninja-build \
+          cmake \
+          build-essential \
+          autoconf \
+          automake \
+          libtool \
+          nasm \
+          pkg-config \
+          libavcodec-dev \
+          libavformat-dev \
+          libavutil-dev \
+          libswscale-dev \
+          libavdevice-dev \
+          libavfilter-dev
 
     - name: Configure CMake
       run: cmake --preset linux-debug


### PR DESCRIPTION
## Summary
- remove YAML anchor from compression-test workflow to comply with GitHub Actions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68856d070454832b8f109ecb30d6132e