### PR TITLE
Add Android frame display capability

### DIFF
--- a/android/app/src/main/cpp/android_client.cpp
+++ b/android/app/src/main/cpp/android_client.cpp
@@ -7,6 +7,10 @@
 #include <string>
 #include <atomic>
 
+static JavaVM* g_vm = nullptr;
+static jclass g_clientClass = nullptr;
+static jmethodID g_onFrameMethod = nullptr;
+
 #define LOG_TAG "MRDesktopClient"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
@@ -23,6 +27,22 @@ public:
         
         receiver.SetFrameCallback([](const FrameMessage& msg, const std::vector<uint8_t>& data) {
             LOGI("Received frame: %dx%d, size: %zu bytes", msg.width, msg.height, data.size());
+            if (g_vm && g_onFrameMethod && g_clientClass) {
+                JNIEnv* env = nullptr;
+                bool attached = (g_vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK);
+                if (attached) {
+                    if (g_vm->AttachCurrentThread(&env, nullptr) != JNI_OK) {
+                        return;
+                    }
+                }
+                jbyteArray arr = env->NewByteArray(data.size());
+                env->SetByteArrayRegion(arr, 0, data.size(), reinterpret_cast<const jbyte*>(data.data()));
+                env->CallStaticVoidMethod(g_clientClass, g_onFrameMethod, arr, (jint)msg.width, (jint)msg.height);
+                env->DeleteLocalRef(arr);
+                if (attached) {
+                    g_vm->DetachCurrentThread();
+                }
+            }
         });
         
         receiver.SetErrorCallback([](const std::string& error) {
@@ -132,6 +152,17 @@ Java_com_mrdesktop_MRDesktopClient_nativeSendMouseClick(JNIEnv *env, jobject thi
         return JNI_FALSE;
     }
     return g_client->SendMouseClick(button, pressed == JNI_TRUE) ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT void JNICALL
+Java_com_mrdesktop_MRDesktopClient_nativeSetFrameCallback(JNIEnv* env, jclass clazz) {
+    env->GetJavaVM(&g_vm);
+    if (g_clientClass) {
+        env->DeleteGlobalRef(g_clientClass);
+        g_clientClass = nullptr;
+    }
+    g_clientClass = reinterpret_cast<jclass>(env->NewGlobalRef(clazz));
+    g_onFrameMethod = env->GetStaticMethodID(g_clientClass, "onFrameReceived", "([BII)V");
 }
 
 }

--- a/android/app/src/main/java/com/mrdesktop/MRDesktopClient.java
+++ b/android/app/src/main/java/com/mrdesktop/MRDesktopClient.java
@@ -4,6 +4,26 @@ public class MRDesktopClient {
     static {
         System.loadLibrary("MRDesktopClient");
     }
+
+    /** Callback interface for delivering decoded frames to Java. */
+    public interface FrameCallback {
+        void onFrame(byte[] data, int width, int height);
+    }
+
+    private static FrameCallback frameCallback;
+
+    /** Called from native code whenever a frame is received. */
+    private static void onFrameReceived(byte[] data, int width, int height) {
+        if (frameCallback != null) {
+            frameCallback.onFrame(data, width, height);
+        }
+    }
+
+    /** Register a callback to receive frames from native code. */
+    public static void setFrameCallback(FrameCallback callback) {
+        frameCallback = callback;
+        nativeSetFrameCallback();
+    }
     
     // Native method declarations
     public native boolean nativeConnect(String serverIP, int port);
@@ -11,6 +31,7 @@ public class MRDesktopClient {
     public native boolean nativeIsConnected();
     public native boolean nativeSendMouseMove(int deltaX, int deltaY);
     public native boolean nativeSendMouseClick(int button, boolean pressed);
+    public static native void nativeSetFrameCallback();
     
     // Java wrapper methods
     public boolean connect(String serverIP, int port) {

--- a/android/app/src/main/java/com/mrdesktop/MainActivity.java
+++ b/android/app/src/main/java/com/mrdesktop/MainActivity.java
@@ -1,0 +1,61 @@
+package com.mrdesktop;
+
+import android.graphics.Bitmap;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.nio.ByteBuffer;
+
+public class MainActivity extends AppCompatActivity {
+    private final MRDesktopClient client = new MRDesktopClient();
+
+    private ImageView imageFrame;
+    private EditText editIP;
+    private EditText editPort;
+    private TextView statusText;
+    private Button btnConnect;
+    private Button btnDisconnect;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
+        imageFrame = findViewById(R.id.imageFrame);
+        editIP = findViewById(R.id.editServerIP);
+        editPort = findViewById(R.id.editServerPort);
+        statusText = findViewById(R.id.textStatus);
+        btnConnect = findViewById(R.id.btnFullConnect);
+        btnDisconnect = findViewById(R.id.btnFullDisconnect);
+
+        MRDesktopClient.setFrameCallback((data, width, height) -> {
+            Bitmap bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+            bmp.copyPixelsFromBuffer(ByteBuffer.wrap(data));
+            runOnUiThread(() -> imageFrame.setImageBitmap(bmp));
+        });
+
+        btnConnect.setOnClickListener(v -> {
+            statusText.setText(getString(R.string.connecting));
+            String ip = editIP.getText().toString();
+            int port = 8080;
+            try {
+                port = Integer.parseInt(editPort.getText().toString());
+            } catch (NumberFormatException ignored) {
+            }
+            new Thread(() -> {
+                boolean ok = client.connect(ip, port);
+                runOnUiThread(() -> statusText.setText(ok ? getString(R.string.connected) : getString(R.string.disconnected)));
+            }).start();
+        });
+
+        btnDisconnect.setOnClickListener(v -> {
+            client.disconnect();
+            statusText.setText(getString(R.string.disconnected));
+        });
+    }
+}

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -118,4 +118,12 @@
 
     </LinearLayout>
 
+    <ImageView
+        android:id="@+id/imageFrame"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:scaleType="fitCenter"
+        android:contentDescription="Remote frame" />
+
 </LinearLayout>


### PR DESCRIPTION
## Summary
- enable frame callbacks in `MRDesktopClient` and expose new native method
- forward decoded frames from native C++ to Java
- create `MainActivity` with simple UI for connecting and showing frames
- insert `ImageView` placeholder into layout for the remote desktop

## Testing
- `gradlew` not available in this environment so Android build could not be run


------
https://chatgpt.com/codex/tasks/task_e_688593fffb38832bb007c1bc7138dc6d