### PR TITLE
Fix GitHub action duplication

### DIFF
--- a/.github/actions/cache-vcpkg/action.yml
+++ b/.github/actions/cache-vcpkg/action.yml
@@ -1,0 +1,14 @@
+name: Cache vcpkg
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/cache@v3
+      with:
+        path: |
+          extern/vcpkg/buildtrees
+          extern/vcpkg/packages
+          extern/vcpkg/downloads
+          extern/vcpkg/installed
+        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -1,0 +1,22 @@
+name: Install dependencies
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          ninja-build \
+          cmake \
+          build-essential \
+          autoconf \
+          automake \
+          libtool \
+          nasm \
+          pkg-config \
+          libavcodec-dev \
+          libavformat-dev \
+          libavutil-dev \
+          libswscale-dev \
+          libavdevice-dev \
+          libavfilter-dev
+      shell: bash

--- a/.github/workflows/compression-test.yml
+++ b/.github/workflows/compression-test.yml
@@ -17,35 +17,10 @@ jobs:
         submodules: recursive
 
     - name: Cache vcpkg
-      uses: actions/cache@v3
-      with:
-        path: |
-          extern/vcpkg/buildtrees
-          extern/vcpkg/packages
-          extern/vcpkg/downloads
-          extern/vcpkg/installed
-        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
-        restore-keys: |
-          ${{ runner.os }}-vcpkg-
+      uses: ./.github/actions/cache-vcpkg
 
     - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          ninja-build \
-          cmake \
-          build-essential \
-          autoconf \
-          automake \
-          libtool \
-          nasm \
-          pkg-config \
-          libavcodec-dev \
-          libavformat-dev \
-          libavutil-dev \
-          libswscale-dev \
-          libavdevice-dev \
-          libavfilter-dev
+      uses: ./.github/actions/install-deps
 
     - name: Setup vcpkg
       run: |
@@ -63,16 +38,7 @@ jobs:
         submodules: recursive
 
     - name: Restore vcpkg from cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          extern/vcpkg/buildtrees
-          extern/vcpkg/packages
-          extern/vcpkg/downloads
-          extern/vcpkg/installed
-        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
-        restore-keys: |
-          ${{ runner.os }}-vcpkg-
+      uses: ./.github/actions/cache-vcpkg
 
     - name: Cache build
       uses: actions/cache@v3
@@ -84,23 +50,7 @@ jobs:
           ${{ runner.os }}-build-
 
     - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          ninja-build \
-          cmake \
-          build-essential \
-          autoconf \
-          automake \
-          libtool \
-          nasm \
-          pkg-config \
-          libavcodec-dev \
-          libavformat-dev \
-          libavutil-dev \
-          libswscale-dev \
-          libavdevice-dev \
-          libavfilter-dev
+      uses: ./.github/actions/install-deps
 
     - name: Configure CMake
       run: cmake --preset linux-debug


### PR DESCRIPTION
## Summary
- refactor compression-test workflow without YAML anchors
- create local composite actions for caching vcpkg and installing dependencies

## Testing
- `pip install pyyaml`
- `python3 - <<'PY'\nimport yaml, sys\nf=open('.github/workflows/compression-test.yml')\nyaml.safe_load(f)\nprint('YAML OK')\nPY`

------
https://chatgpt.com/codex/tasks/task_e_688591a8bdd4832b984c1e4319db401c