### PR TITLE
Add clang-format style and formatting helper

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,126 @@
+# The canary clang-format config file.
+#
+# Changes from head:
+# - AllowAllParametersOfDeclarationOnNextLine: Safe
+# - AllowShortFunctionsOnASingleLine: Safe
+# - IncludeIsMainRegex: May cause errors, as it may reorder includes.
+# - IncludeCategories: May cause errors, as it may reorder includes.
+---
+AccessModifierOffset: -1
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: DontAlign
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit: 80
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat: false
+FixNamespaceComments: true
+ForEachMacros:
+  - FOR_EACH
+  - FOR_EACH_R
+  - FOR_EACH_RANGE
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex:           '^<(sodium|Python)\.h>$'
+    Priority:        3
+  - Regex:           '^<((arpa|net|netinet|sys|linux)\/)?[-_[:alnum:]]+\.h>$'
+    Priority:        1
+  - Regex:           '^<[\/-_[:alnum:]]+>$'
+    Priority:        2
+  - Regex:           '^<((bistro|caffe2|cachelib|fatal|fb303|faiss|fbmeshd|fboss|fbzmq|fizz|folly|gloo|hphp|logdevice|magma|mcrouter|openr|proxygen|quic|rsocket|scape|squangle|tensorpipe|thrift|wangle|wdt|yarpl)\/).*>$'
+    Priority:        4
+  - Regex:           '^<.*>$'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        5
+IncludeIsMainRegex: '((Test|Tests|_test|Bench|Benchmark|Performance)[0-9]*)?$'
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth: 2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 10
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard: Latest
+TabWidth: 8
+UseCRLF: false
+UseTab: Never
+...

--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ To test the desktop video streaming:
 
  The first_frame.bmp file will prove the desktop capture is working
 
+
+## Formatting
+
+The repository uses clang-format to keep the C/C++ code consistent. The style configuration is in `.clang-format`, based on Meta's Snowplow guidelines. Run `scripts/format.sh` after making changes to automatically format the source files.

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Formats all C/C++ source files using clang-format with the repository style.
+set -e
+find src android tests \( -name '*.cpp' -o -name '*.h' \) -print0 | xargs -0 clang-format -i


### PR DESCRIPTION
## Summary
- add clang-format config matching Meta/Facebook Snowplow style
- add a helper script to run clang-format
- document formatting instructions in the README

## Testing
- `./scripts/format.sh`
- `cmake -S . -B build` *(fails: could not find FFMPEG)*

------
https://chatgpt.com/codex/tasks/task_e_688659b3495c832bb38ecbdd00be5450