### PR TITLE
Fix mouse click button expectation

### DIFF
--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -65,7 +65,7 @@ TEST_F(ProtocolTest, MouseClickMessage) {
   msg.pressed = true;
 
   EXPECT_EQ(msg.header.type, MSG_MOUSE_CLICK);
-  EXPECT_EQ(msg.button, 0);
+  EXPECT_EQ(msg.button, MouseClickMessage::LEFT_BUTTON);
   EXPECT_TRUE(msg.pressed);
 }
 


### PR DESCRIPTION
## Summary
- match expected mouse click value with `MouseClickMessage::LEFT_BUTTON`

## Testing
- `cmake --preset linux-debug` *(fails: mfx-dispatch build error)*

------
https://chatgpt.com/codex/tasks/task_e_6886fc6ccf14832b9af06cd33d34528e