### PR TITLE
Validate frame logger dimensions

### DIFF
--- a/src/shared/FrameLogger.cpp
+++ b/src/shared/FrameLogger.cpp
@@ -32,6 +32,13 @@ bool FrameLogger::LogFrame(
     return false;
   }
 
+  // Validate dimensions to avoid corrupt or malicious data
+  if (width == 0 || height == 0 || width > 10000 || height > 10000) {
+    std::cerr << "FrameLogger: Invalid frame dimensions (" << width << "x"
+              << height << ")" << std::endl;
+    return false;
+  }
+
   LoggedFrame frame;
   frame.frameIndex = m_frameCounter++;
   frame.width = width;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,8 +23,10 @@ add_executable(basic_tests
     test_protocol.cpp
     test_video_encoder.cpp
     test_ffmpeg_video_decoder.cpp
+    test_frame_logger.cpp
     ../src/shared/VideoEncoder.cpp
     ../src/shared/FFmpegVideoDecoder.cpp
+    ../src/shared/FrameLogger.cpp
     ../src/shared/Logging.cpp
 )
 

--- a/tests/test_frame_logger.cpp
+++ b/tests/test_frame_logger.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+#include "FrameLogger.h"
+
+class FrameLoggerTest : public ::testing::Test {};
+
+TEST_F(FrameLoggerTest, LogsValidFrame) {
+    FrameLogger logger(5, "");
+    uint32_t width = 640;
+    uint32_t height = 480;
+    std::vector<uint8_t> data(width * height * 4, 0);
+    EXPECT_TRUE(logger.LogFrame(width, height, data.size(), data.data()));
+    EXPECT_EQ(logger.GetFrameCount(), 1u);
+}
+
+TEST_F(FrameLoggerTest, RejectsZeroDimensions) {
+    FrameLogger logger;
+    std::vector<uint8_t> data(4, 0);
+    EXPECT_FALSE(logger.LogFrame(0, 480, data.size(), data.data()));
+    EXPECT_EQ(logger.GetFrameCount(), 0u);
+}
+
+TEST_F(FrameLoggerTest, RejectsTooLargeDimensions) {
+    FrameLogger logger;
+    std::vector<uint8_t> data(4, 0);
+    EXPECT_FALSE(logger.LogFrame(10001, 1, data.size(), data.data()));
+    EXPECT_EQ(logger.GetFrameCount(), 0u);
+}


### PR DESCRIPTION
## Summary
- validate frame dimensions in `FrameLogger`
- add `FrameLogger` unit tests
- compile tests with `FrameLogger`

## Testing
- `cmake -B build -S . -DBUILD_TESTS=ON` *(fails: could not find FFMPEG)*

------
https://chatgpt.com/codex/tasks/task_e_6886fc595134832bb590e006894751da