### PR TITLE
Deduplicate SaveFrameAsBMP helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ if(PLATFORM_DESKTOP)
     add_executable(MRDesktopConsoleClient
         src/clients/console/main.cpp
         src/shared/FrameLogger.cpp
+        src/shared/FrameUtils.cpp
         src/shared/AsioNetworking.cpp
         src/shared/NetworkReceiver.cpp
         src/shared/FFmpegVideoDecoder.cpp

--- a/src/clients/console/main.cpp
+++ b/src/clients/console/main.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #ifdef _WIN32
 #include <conio.h>
-#include <windows.h>
 #else
 #include <fcntl.h>
 #include <sys/ioctl.h>
@@ -17,32 +16,10 @@
 #include "FFmpegVideoDecoder.h"
 #include "FrameLogger.h"
 #define LOG_TAG "MRDesk.Console"
+#include "FrameUtils.h"
 #include "Logging.h"
 #include "NetworkReceiver.h"
 #include "protocol.h"
-
-#pragma pack(push, 1)
-struct BMPFileHeader {
-  uint16_t bfType{0};
-  uint32_t bfSize{0};
-  uint16_t bfReserved1{0};
-  uint16_t bfReserved2{0};
-  uint32_t bfOffBits{0};
-};
-struct BMPInfoHeader {
-  uint32_t biSize{0};
-  int32_t biWidth{0};
-  int32_t biHeight{0};
-  uint16_t biPlanes{1};
-  uint16_t biBitCount{0};
-  uint32_t biCompression{0};
-  uint32_t biSizeImage{0};
-  int32_t biXPelsPerMeter{0};
-  int32_t biYPelsPerMeter{0};
-  uint32_t biClrUsed{0};
-  uint32_t biClrImportant{0};
-};
-#pragma pack(pop)
 
 #ifndef _WIN32
 static int _kbhit() {
@@ -62,58 +39,6 @@ static int _getch() {
   return ch;
 }
 #endif
-
-void SaveFrameAsBMP(
-    const FrameMessage& frameMsg,
-    const std::vector<uint8_t>& frameData,
-    const std::string& filename) {
-  BMPFileHeader fileHeader{};
-  BMPInfoHeader infoHeader{};
-
-  fileHeader.bfType = 0x4D42; // "BM"
-  fileHeader.bfSize =
-      sizeof(BMPFileHeader) + sizeof(BMPInfoHeader) + frameData.size();
-  fileHeader.bfOffBits = sizeof(BMPFileHeader) + sizeof(BMPInfoHeader);
-
-  infoHeader.biSize = sizeof(BMPInfoHeader);
-  infoHeader.biWidth = static_cast<int32_t>(frameMsg.width);
-  infoHeader.biHeight = -static_cast<int32_t>(frameMsg.height); // top-down
-  infoHeader.biPlanes = 1;
-  infoHeader.biBitCount = 32;
-  infoHeader.biCompression = 0; // BI_RGB
-  infoHeader.biSizeImage = static_cast<uint32_t>(frameData.size());
-
-#ifdef _WIN32
-  HANDLE hFile = CreateFileA(
-      filename.c_str(),
-      GENERIC_WRITE,
-      0,
-      nullptr,
-      CREATE_ALWAYS,
-      FILE_ATTRIBUTE_NORMAL,
-      nullptr);
-  if (hFile != INVALID_HANDLE_VALUE) {
-    DWORD written;
-    WriteFile(hFile, &fileHeader, sizeof(fileHeader), &written, nullptr);
-    WriteFile(hFile, &infoHeader, sizeof(infoHeader), &written, nullptr);
-    WriteFile(hFile, frameData.data(), frameData.size(), &written, nullptr);
-    CloseHandle(hFile);
-    std::cout << "Saved frame as " << filename << std::endl;
-  }
-#else
-  std::ofstream out(filename, std::ios::binary);
-  if (out.is_open()) {
-    out.write(reinterpret_cast<const char*>(&fileHeader), sizeof(fileHeader));
-    out.write(reinterpret_cast<const char*>(&infoHeader), sizeof(infoHeader));
-    out.write(
-        reinterpret_cast<const char*>(frameData.data()), frameData.size());
-    out.close();
-    std::cout << "Saved frame as " << filename << std::endl;
-  } else {
-    std::cerr << "Failed to open " << filename << " for writing" << std::endl;
-  }
-#endif
-}
 
 void PrintUsage() {
   std::cout << "MRDesktop Console Client - Remote Desktop Controller"
@@ -337,7 +262,8 @@ int main(int argc, char* argv[]) {
 
     // Save first frame as BMP for verification (legacy behavior)
     if (!savedFirstFrame) {
-      SaveFrameAsBMP(frameMsg, frameData, "first_frame.bmp");
+      SaveFrameAsBMP(
+          frameMsg.width, frameMsg.height, frameData, "first_frame.bmp");
       savedFirstFrame = true;
       std::cout << "First frame saved as first_frame.bmp" << std::endl;
     }

--- a/src/shared/FrameLogger.cpp
+++ b/src/shared/FrameLogger.cpp
@@ -5,6 +5,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include "FrameUtils.h"
 #ifdef _WIN32
 #define NOMINMAX
 #include <windows.h>
@@ -50,60 +51,6 @@ bool FrameLogger::LogFrame(
             << "x" << height << ", " << dataSize << " bytes)" << std::endl;
 
   return true;
-}
-
-bool FrameLogger::SaveFrameAsBMP(
-    uint32_t width,
-    uint32_t height,
-    const std::vector<uint8_t>& frameData,
-    const std::string& filename) {
-#ifdef _WIN32
-  // Create BMP file headers (assumes BGRA format)
-  BITMAPFILEHEADER fileHeader = {};
-  BITMAPINFOHEADER infoHeader = {};
-
-  fileHeader.bfType = 0x4D42; // "BM"
-  fileHeader.bfSize =
-      sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) + frameData.size();
-  fileHeader.bfOffBits = sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER);
-
-  infoHeader.biSize = sizeof(BITMAPINFOHEADER);
-  infoHeader.biWidth = width;
-  infoHeader.biHeight = -(int)height; // Top-down DIB
-  infoHeader.biPlanes = 1;
-  infoHeader.biBitCount = 32;
-  infoHeader.biCompression = BI_RGB;
-  infoHeader.biSizeImage = frameData.size();
-
-  HANDLE hFile = CreateFileA(
-      filename.c_str(),
-      GENERIC_WRITE,
-      0,
-      nullptr,
-      CREATE_ALWAYS,
-      FILE_ATTRIBUTE_NORMAL,
-      nullptr);
-  if (hFile != INVALID_HANDLE_VALUE) {
-    DWORD written;
-    bool success =
-        WriteFile(hFile, &fileHeader, sizeof(fileHeader), &written, nullptr) &&
-        WriteFile(hFile, &infoHeader, sizeof(infoHeader), &written, nullptr) &&
-        WriteFile(hFile, frameData.data(), frameData.size(), &written, nullptr);
-    CloseHandle(hFile);
-    return success;
-  }
-  return false;
-#else
-  // For non-Windows platforms, save as raw data for now
-  std::ofstream file(filename, std::ios::binary);
-  if (file.is_open()) {
-    file.write(
-        reinterpret_cast<const char*>(frameData.data()), frameData.size());
-    file.close();
-    return true;
-  }
-  return false;
-#endif
 }
 
 void FrameLogger::SaveFramesToDisk() {

--- a/src/shared/FrameLogger.h
+++ b/src/shared/FrameLogger.h
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#include "FrameUtils.h"
 
 struct LoggedFrame {
   uint32_t frameIndex;
@@ -54,9 +55,4 @@ class FrameLogger {
   void EnsureOutputDirectory();
   std::string GenerateFrameFilename(
       uint32_t frameIndex, uint32_t width, uint32_t height);
-  bool SaveFrameAsBMP(
-      uint32_t width,
-      uint32_t height,
-      const std::vector<uint8_t>& frameData,
-      const std::string& filename);
 };

--- a/src/shared/FrameUtils.cpp
+++ b/src/shared/FrameUtils.cpp
@@ -1,0 +1,35 @@
+#include "FrameUtils.h"
+#include <fstream>
+
+bool SaveFrameAsBMP(
+    uint32_t width,
+    uint32_t height,
+    const std::vector<uint8_t>& frameData,
+    const std::string& filename) {
+  BMPFileHeader fileHeader{};
+  BMPInfoHeader infoHeader{};
+
+  fileHeader.bfType = 0x4D42; // "BM"
+  fileHeader.bfSize =
+      sizeof(BMPFileHeader) + sizeof(BMPInfoHeader) + frameData.size();
+  fileHeader.bfOffBits = sizeof(BMPFileHeader) + sizeof(BMPInfoHeader);
+
+  infoHeader.biSize = sizeof(BMPInfoHeader);
+  infoHeader.biWidth = static_cast<int32_t>(width);
+  infoHeader.biHeight = -static_cast<int32_t>(height);
+  infoHeader.biPlanes = 1;
+  infoHeader.biBitCount = 32;
+  infoHeader.biCompression = 0;
+  infoHeader.biSizeImage = static_cast<uint32_t>(frameData.size());
+
+  std::ofstream out(filename, std::ios::binary);
+  if (!out.is_open()) {
+    return false;
+  }
+
+  out.write(reinterpret_cast<const char*>(&fileHeader), sizeof(fileHeader));
+  out.write(reinterpret_cast<const char*>(&infoHeader), sizeof(infoHeader));
+  out.write(reinterpret_cast<const char*>(frameData.data()), frameData.size());
+
+  return out.good();
+}

--- a/src/shared/FrameUtils.h
+++ b/src/shared/FrameUtils.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <chrono>
+#include <cstdint>
 #include <functional>
+#include <string>
 #include <thread>
 #include <vector>
 #include "protocol.h"
@@ -89,3 +91,33 @@ inline bool ReadFrameGeneric(
     return false;
   return true;
 }
+
+#pragma pack(push, 1)
+struct BMPFileHeader {
+  uint16_t bfType{0};
+  uint32_t bfSize{0};
+  uint16_t bfReserved1{0};
+  uint16_t bfReserved2{0};
+  uint32_t bfOffBits{0};
+};
+
+struct BMPInfoHeader {
+  uint32_t biSize{0};
+  int32_t biWidth{0};
+  int32_t biHeight{0};
+  uint16_t biPlanes{1};
+  uint16_t biBitCount{0};
+  uint32_t biCompression{0};
+  uint32_t biSizeImage{0};
+  int32_t biXPelsPerMeter{0};
+  int32_t biYPelsPerMeter{0};
+  uint32_t biClrUsed{0};
+  uint32_t biClrImportant{0};
+};
+#pragma pack(pop)
+
+bool SaveFrameAsBMP(
+    uint32_t width,
+    uint32_t height,
+    const std::vector<uint8_t>& frameData,
+    const std::string& filename);


### PR DESCRIPTION
## Summary
- introduce shared FrameUtils.cpp with SaveFrameAsBMP helper
- expose BMP header structs and SaveFrameAsBMP in FrameUtils.h
- update FrameLogger to use shared helper
- remove duplicated code from console client
- add FrameUtils.cpp to console build

## Testing
- `sh linux/build-linux.sh test` *(fails: podman not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6886fc461034832bb757cc6e8d5acf74