### PR TITLE
Translate Quest touch events to desktop clicks

### DIFF
--- a/android/app/src/main/cpp/android_client.cpp
+++ b/android/app/src/main/cpp/android_client.cpp
@@ -309,8 +309,13 @@ class AndroidNetworkClient {
     }
   }
 
-  bool SendMouseMove(int32_t deltaX, int32_t deltaY) {
-    return receiver->SendMouseMove(deltaX, deltaY);
+  bool SendMouseMove(
+      int32_t deltaX,
+      int32_t deltaY,
+      bool absolute = false,
+      int32_t x = 0,
+      int32_t y = 0) {
+    return receiver->SendMouseMove(deltaX, deltaY, absolute, x, y);
   }
 
   bool SendMouseClick(int button, bool pressed) {
@@ -375,6 +380,15 @@ Java_com_mrdesktop_MRDesktopClient_nativeSendMouseMove(
     return JNI_FALSE;
   }
   return g_client->SendMouseMove(deltaX, deltaY) ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_mrdesktop_MRDesktopClient_nativeSendMouseMoveAbsolute(
+    JNIEnv* env, jobject thiz, jint x, jint y) {
+  if (!g_client) {
+    return JNI_FALSE;
+  }
+  return g_client->SendMouseMove(0, 0, true, x, y) ? JNI_TRUE : JNI_FALSE;
 }
 
 JNIEXPORT jboolean JNICALL

--- a/android/app/src/main/java/com/mrdesktop/MRDesktopClient.java
+++ b/android/app/src/main/java/com/mrdesktop/MRDesktopClient.java
@@ -30,6 +30,7 @@ public class MRDesktopClient {
     public native void nativeDisconnect();
     public native boolean nativeIsConnected();
     public native boolean nativeSendMouseMove(int deltaX, int deltaY);
+    public native boolean nativeSendMouseMoveAbsolute(int x, int y);
     public native boolean nativeSendMouseClick(int button, boolean pressed);
     public static native void nativeSetFrameCallback(Class<?> clazz);
     
@@ -48,6 +49,10 @@ public class MRDesktopClient {
     
     public boolean sendMouseMove(int deltaX, int deltaY) {
         return nativeSendMouseMove(deltaX, deltaY);
+    }
+
+    public boolean sendMouseMoveAbsolute(int x, int y) {
+        return nativeSendMouseMoveAbsolute(x, y);
     }
     
     public boolean sendMouseClick(int button, boolean pressed) {

--- a/android/app/src/main/java/com/mrdesktop/MainActivity.java
+++ b/android/app/src/main/java/com/mrdesktop/MainActivity.java
@@ -3,6 +3,7 @@ package com.mrdesktop;
 import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.view.View;
+import android.view.MotionEvent;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
@@ -22,6 +23,8 @@ public class MainActivity extends AppCompatActivity {
     private Button btnConnection;
     private Button btnTest;
     private boolean isConnected = false;
+    private int remoteWidth = 0;
+    private int remoteHeight = 0;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -41,6 +44,8 @@ public class MainActivity extends AppCompatActivity {
 
         // Set up frame callback before any connection attempts
         MRDesktopClient.setFrameCallback((data, width, height) -> {
+            remoteWidth = width;
+            remoteHeight = height;
             android.util.Log.d("MRDesktop", "Frame callback received: " + data.length + " bytes, " + width + "x" + height);
             try {
                 // Check if we have enough data for ARGB_8888 format
@@ -58,6 +63,48 @@ public class MainActivity extends AppCompatActivity {
             } catch (Exception e) {
                 android.util.Log.e("MRDesktop", "Error processing frame: " + e.getMessage());
             }
+        });
+
+        imageFrame.setOnTouchListener((v, event) -> {
+            if (!isConnected) {
+                return true;
+            }
+
+            int action = event.getAction();
+            if (action == MotionEvent.ACTION_DOWN ||
+                action == MotionEvent.ACTION_MOVE ||
+                action == MotionEvent.ACTION_UP) {
+
+                int viewW = v.getWidth();
+                int viewH = v.getHeight();
+                if (viewW == 0 || viewH == 0 || remoteWidth == 0 || remoteHeight == 0) {
+                    return true;
+                }
+
+                float scale = Math.min((float) viewW / remoteWidth, (float) viewH / remoteHeight);
+                float imgW = remoteWidth * scale;
+                float imgH = remoteHeight * scale;
+                float offsetX = (viewW - imgW) / 2f;
+                float offsetY = (viewH - imgH) / 2f;
+
+                float remoteXf = (event.getX() - offsetX) / scale;
+                float remoteYf = (event.getY() - offsetY) / scale;
+                int remoteX = Math.round(remoteXf);
+                int remoteY = Math.round(remoteYf);
+
+                if (remoteX < 0 || remoteX >= remoteWidth || remoteY < 0 || remoteY >= remoteHeight) {
+                    return true;
+                }
+
+                client.sendMouseMoveAbsolute(remoteX, remoteY);
+
+                if (action == MotionEvent.ACTION_DOWN) {
+                    client.sendMouseClick(0, true);
+                } else if (action == MotionEvent.ACTION_UP) {
+                    client.sendMouseClick(0, false);
+                }
+            }
+            return true;
         });
 
         btnConnection.setOnClickListener(v -> {


### PR DESCRIPTION
## Summary
- add JNI function to send absolute mouse moves
- expose `sendMouseMoveAbsolute` in `MRDesktopClient`
- store remote frame dimensions and convert touch positions to mouse events

## Testing
- `cmake --preset linux-debug` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_688741389798832bac92fbbd1f356a5b