### PR TITLE
Refactor per-message input callbacks

### DIFF
--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -538,7 +538,6 @@ class MRDesktopServer {
 #endif
   }
 
-
   bool IsTestCompleted() const { return m_testCompleted; }
 
   void Poll() {
@@ -555,10 +554,43 @@ class MRDesktopServer {
     m_currentClient = client;
 
     // Setup client callbacks
-    client->SetInputCallback(
-        [this](const MessageHeader& header, const std::vector<uint8_t>& data) {
-          HandleInputMessage(header, data);
+    client->SetCompressionRequestCallback(
+        [this](const CompressionRequestMessage& msg) {
+          std::cout << "Processing compression request" << std::endl;
+          m_clientCompression = msg.compression;
+          std::cout << "Client requested compression type: "
+                    << m_clientCompression << std::endl;
+          std::cout << "Server now configured for compression type: "
+                    << m_clientCompression << std::endl;
         });
+
+    client->SetPixelFormatRequestCallback(
+        [this](const PixelFormatRequestMessage& msg) {
+          std::cout << "Processing pixel format request" << std::endl;
+          PixelFormat requestedFormat = msg.preferredFormat;
+          std::cout << "Client requested pixel format: " << requestedFormat
+                    << std::endl;
+          m_clientPixelFormat = requestedFormat;
+        });
+
+    client->SetMouseMoveCallback([](const MouseMoveMessage& msg) {
+      InputInjector::InjectMouseMove(
+          msg.deltaX, msg.deltaY, msg.absolute, msg.x, msg.y);
+      std::cout << "Mouse move: dx=" << msg.deltaX << " dy=" << msg.deltaY
+                << std::endl;
+    });
+
+    client->SetMouseClickCallback([](const MouseClickMessage& msg) {
+      InputInjector::InjectMouseClick(msg.button, msg.pressed);
+      std::cout << "Mouse " << (msg.pressed ? "press" : "release") << " button "
+                << msg.button << std::endl;
+    });
+
+    client->SetMouseScrollCallback([](const MouseScrollMessage& msg) {
+      InputInjector::InjectMouseScroll(msg.deltaX, msg.deltaY);
+      std::cout << "Mouse scroll: dx=" << msg.deltaX << " dy=" << msg.deltaY
+                << std::endl;
+    });
 
     client->SetErrorCallback([this](const std::string& error) {
       std::cerr << "Client error: " << error << std::endl;
@@ -573,96 +605,6 @@ class MRDesktopServer {
     // Start streaming
     m_streaming = true;
     m_streamingThread = std::thread([this]() { StreamingLoop(); });
-  }
-
-  void HandleInputMessage(
-      const MessageHeader& header, const std::vector<uint8_t>& data) {
-    std::cout << "HandleInputMessage: type=" << header.type << " size="
-              << header.size << " data.size()=" << data.size() << std::endl;
-    switch (header.type) {
-      case MSG_COMPRESSION_REQUEST: {
-        std::cout << "Processing compression request" << std::endl;
-        if (data.size() >= sizeof(CompressionType)) {
-          // Extract compression type from the data payload
-          m_clientCompression =
-              *reinterpret_cast<const CompressionType*>(data.data());
-          std::cout << "Client requested compression type: "
-                    << m_clientCompression << std::endl;
-
-          // Send acknowledgment back to client (optional but good practice)
-          std::cout << "Server now configured for compression type: "
-                    << m_clientCompression << std::endl;
-        } else {
-          std::cout << "Invalid compression request size: " << data.size()
-                    << " expected: " << sizeof(CompressionType) << std::endl;
-        }
-        break;
-      }
-      case MSG_PIXEL_FORMAT_REQUEST: {
-        std::cout << "Processing pixel format request" << std::endl;
-        if (data.size() >= sizeof(PixelFormat)) {
-          // Extract preferred pixel format from the data payload
-          PixelFormat requestedFormat =
-              *reinterpret_cast<const PixelFormat*>(data.data());
-          std::cout << "Client requested pixel format: " << requestedFormat
-                    << std::endl;
-
-          // For now, honor the client's request (could add validation logic
-          // here)
-          m_clientPixelFormat = requestedFormat;
-        } else {
-          std::cout << "Invalid pixel format request size: " << data.size()
-                    << " expected: " << sizeof(PixelFormat) << std::endl;
-        }
-        break;
-      }
-      case MSG_MOUSE_MOVE: {
-        if (data.size() >= sizeof(MouseMoveMessage) - sizeof(MessageHeader)) {
-          // Create a complete MouseMoveMessage by combining header and data
-          MouseMoveMessage msg;
-          msg.header = header;
-          memcpy(
-              reinterpret_cast<char*>(&msg) + sizeof(MessageHeader),
-              data.data(),
-              data.size());
-          InputInjector::InjectMouseMove(
-              msg.deltaX, msg.deltaY, msg.absolute, msg.x, msg.y);
-          std::cout << "Mouse move: dx=" << msg.deltaX << " dy=" << msg.deltaY
-                    << std::endl;
-        }
-        break;
-      }
-      case MSG_MOUSE_CLICK: {
-        if (data.size() >= sizeof(MouseClickMessage) - sizeof(MessageHeader)) {
-          // Create a complete MouseClickMessage by combining header and data
-          MouseClickMessage msg;
-          msg.header = header;
-          memcpy(
-              reinterpret_cast<char*>(&msg) + sizeof(MessageHeader),
-              data.data(),
-              data.size());
-          InputInjector::InjectMouseClick(msg.button, msg.pressed);
-          std::cout << "Mouse " << (msg.pressed ? "press" : "release")
-                    << " button " << msg.button << std::endl;
-        }
-        break;
-      }
-      case MSG_MOUSE_SCROLL: {
-        if (data.size() >= sizeof(MouseScrollMessage) - sizeof(MessageHeader)) {
-          // Create a complete MouseScrollMessage by combining header and data
-          MouseScrollMessage msg;
-          msg.header = header;
-          memcpy(
-              reinterpret_cast<char*>(&msg) + sizeof(MessageHeader),
-              data.data(),
-              data.size());
-          InputInjector::InjectMouseScroll(msg.deltaX, msg.deltaY);
-          std::cout << "Mouse scroll: dx=" << msg.deltaX << " dy=" << msg.deltaY
-                    << std::endl;
-        }
-        break;
-      }
-    }
   }
 
   void StreamingLoop() {

--- a/src/shared/AsioNetworking.cpp
+++ b/src/shared/AsioNetworking.cpp
@@ -323,57 +323,52 @@ void AsioConnection::ProcessCompleteMessage() {
       break;
     }
     case MSG_MOUSE_MOVE: {
-      std::vector<uint8_t> messageData(
-          m_accumBuffer.begin() + sizeof(MessageHeader),
-          m_accumBuffer.begin() + m_bytesNeeded);
+      MouseMoveMessage msg;
+      memcpy(&msg, m_accumBuffer.data(), sizeof(MouseMoveMessage));
 
       LOGD("Processing mouse move message");
-      if (m_onInput) {
-        m_onInput(header, messageData);
+      if (m_onMouseMove) {
+        m_onMouseMove(msg);
       }
       break;
     }
     case MSG_MOUSE_CLICK: {
-      std::vector<uint8_t> messageData(
-          m_accumBuffer.begin() + sizeof(MessageHeader),
-          m_accumBuffer.begin() + m_bytesNeeded);
+      MouseClickMessage msg;
+      memcpy(&msg, m_accumBuffer.data(), sizeof(MouseClickMessage));
 
       LOGD("Processing mouse click message");
-      if (m_onInput) {
-        m_onInput(header, messageData);
+      if (m_onMouseClick) {
+        m_onMouseClick(msg);
       }
       break;
     }
     case MSG_MOUSE_SCROLL: {
-      std::vector<uint8_t> messageData(
-          m_accumBuffer.begin() + sizeof(MessageHeader),
-          m_accumBuffer.begin() + m_bytesNeeded);
+      MouseScrollMessage msg;
+      memcpy(&msg, m_accumBuffer.data(), sizeof(MouseScrollMessage));
 
       LOGD("Processing mouse scroll message");
-      if (m_onInput) {
-        m_onInput(header, messageData);
+      if (m_onMouseScroll) {
+        m_onMouseScroll(msg);
       }
       break;
     }
     case MSG_COMPRESSION_REQUEST: {
-      std::vector<uint8_t> messageData(
-          m_accumBuffer.begin() + sizeof(MessageHeader),
-          m_accumBuffer.begin() + m_bytesNeeded);
+      CompressionRequestMessage msg;
+      memcpy(&msg, m_accumBuffer.data(), sizeof(CompressionRequestMessage));
 
       LOGD("Processing compression request message");
-      if (m_onInput) {
-        m_onInput(header, messageData);
+      if (m_onCompressionRequest) {
+        m_onCompressionRequest(msg);
       }
       break;
     }
     case MSG_PIXEL_FORMAT_REQUEST: {
-      std::vector<uint8_t> messageData(
-          m_accumBuffer.begin() + sizeof(MessageHeader),
-          m_accumBuffer.begin() + m_bytesNeeded);
+      PixelFormatRequestMessage msg;
+      memcpy(&msg, m_accumBuffer.data(), sizeof(PixelFormatRequestMessage));
 
       LOGD("Processing pixel format request message");
-      if (m_onInput) {
-        m_onInput(header, messageData);
+      if (m_onPixelFormatRequest) {
+        m_onPixelFormatRequest(msg);
       }
       break;
     }

--- a/src/shared/AsioNetworking.h
+++ b/src/shared/AsioNetworking.h
@@ -24,8 +24,13 @@ class AsioConnection {
       std::function<void(const FrameMessage&, const std::vector<uint8_t>&)>;
   using CompressedFrameCallback = std::function<void(
       const CompressedFrameMessage&, const std::vector<uint8_t>&)>;
-  using InputCallback =
-      std::function<void(const MessageHeader&, const std::vector<uint8_t>&)>;
+  using MouseMoveCallback = std::function<void(const MouseMoveMessage&)>;
+  using MouseClickCallback = std::function<void(const MouseClickMessage&)>;
+  using MouseScrollCallback = std::function<void(const MouseScrollMessage&)>;
+  using CompressionRequestCallback =
+      std::function<void(const CompressionRequestMessage&)>;
+  using PixelFormatRequestCallback =
+      std::function<void(const PixelFormatRequestMessage&)>;
   using ErrorCallback = std::function<void(const std::string&)>;
   using DisconnectCallback = std::function<void()>;
 
@@ -37,7 +42,11 @@ class AsioConnection {
   // Callbacks
   FrameCallback m_onFrame;
   CompressedFrameCallback m_onCompressedFrame;
-  InputCallback m_onInput;
+  MouseMoveCallback m_onMouseMove;
+  MouseClickCallback m_onMouseClick;
+  MouseScrollCallback m_onMouseScroll;
+  CompressionRequestCallback m_onCompressionRequest;
+  PixelFormatRequestCallback m_onPixelFormatRequest;
   ErrorCallback m_onError;
   DisconnectCallback m_onDisconnect;
 
@@ -97,7 +106,21 @@ class AsioConnection {
   void SetCompressedFrameCallback(CompressedFrameCallback callback) {
     m_onCompressedFrame = callback;
   }
-  void SetInputCallback(InputCallback callback) { m_onInput = callback; }
+  void SetMouseMoveCallback(MouseMoveCallback callback) {
+    m_onMouseMove = callback;
+  }
+  void SetMouseClickCallback(MouseClickCallback callback) {
+    m_onMouseClick = callback;
+  }
+  void SetMouseScrollCallback(MouseScrollCallback callback) {
+    m_onMouseScroll = callback;
+  }
+  void SetCompressionRequestCallback(CompressionRequestCallback callback) {
+    m_onCompressionRequest = callback;
+  }
+  void SetPixelFormatRequestCallback(PixelFormatRequestCallback callback) {
+    m_onPixelFormatRequest = callback;
+  }
   void SetErrorCallback(ErrorCallback callback) { m_onError = callback; }
   void SetDisconnectCallback(DisconnectCallback callback) {
     m_onDisconnect = callback;


### PR DESCRIPTION
## Summary
- remove generic input callback
- add typed callbacks for mouse and setup requests in `AsioNetworking`
- use new per-message handlers in server

## Testing
- `./linux/build-linux.sh test debug` *(fails: podman not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68879cf1bb74832b91a1e299664f9010