### PR TITLE
Add mfx-dispatch dependency

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -22,17 +22,21 @@
       "default-features": false,
       "platform": "windows",
       "features": [
-        "amf", 
-        "avcodec", 
-        "avformat", 
+        "amf",
+        "avcodec",
+        "avformat",
         "gpl",
         "nvcodec",
         "qsv",
-        "swresample", 
+        "swresample",
         "swscale",
         "x264",
         "x265"
       ]
+    },
+    {
+      "name": "mfx-dispatch",
+      "platform": "linux"
     },
     {
       "name": "gtest",


### PR DESCRIPTION
## Summary
- build libmfx on Linux by installing `mfx-dispatch`

## Testing
- `scripts/format.sh`
- `cmake --preset linux-debug` *(fails: could not finish because build dependencies require network access)*

------
https://chatgpt.com/codex/tasks/task_e_68887447d21c832b9e8cde982d4e8dc9