### PR TITLE
Fix artifact uploads for deprecated v3

### DIFF
--- a/.github/workflows/foundation_tests.yml
+++ b/.github/workflows/foundation_tests.yml
@@ -101,7 +101,7 @@ jobs:
       continue-on-error: true
       
     - name: Upload test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test-results-${{ matrix.os }}-${{ matrix.config }}

--- a/.github/workflows/rtp_tests.yml
+++ b/.github/workflows/rtp_tests.yml
@@ -75,7 +75,7 @@ jobs:
         fi
         
     - name: Upload RTP test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: rtp-test-results-${{ matrix.os }}-${{ matrix.config }}


### PR DESCRIPTION
## Summary
- update `actions/upload-artifact` to v4 in workflows

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68888917b65c832b91ff8465299a9694